### PR TITLE
Switch to php7 in travis before dependency installation in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 sudo: false # use container-based Travis infrastructure
 node_js:
   - "6"
+before_install:
+  - phpenv global 7.0 #switch to php7, since that's what php-Tooling extension requires
 before_script:
   - npm install -g grunt-cli
   - npm install -g jasmine-node


### PR DESCRIPTION
php-Tooling npm package requires felixfbecker/language-server php
package, which can only be installed on php7. This should fix the break
in brackets travis build, caused by php5 being the default php